### PR TITLE
Fix parsing of TFDT

### DIFF
--- a/ingest-tools/fmp4stream.h
+++ b/ingest-tools/fmp4stream.h
@@ -133,7 +133,6 @@ namespace fMP4Stream {
 
 	struct tfdt : public full_box
 	{
-		unsigned int m_version;
 		uint64_t m_basemediadecodetime;
 		tfdt() { m_btype = string("tfdt"); };
 


### PR DESCRIPTION
A local `m_version` was present in `tfdt`, defaulting to 0, which caused the baseMediaDecodeTime to be read as 32 bits regardless of the signalled version.

Removing this resolves the issue since the `full_box` `m_version` is used as expected.